### PR TITLE
feat(css): Adds a linter rule to prevent magic numbers in css

### DIFF
--- a/packages/css/.stylelintrc.js
+++ b/packages/css/.stylelintrc.js
@@ -3,7 +3,10 @@ module.exports = {
     require.resolve("stylelint-config-suitcss"),
     require.resolve("stylelint-config-prettier"),
   ],
-  plugins: [require.resolve("stylelint-selector-bem-pattern")],
+  plugins: [
+    require.resolve("stylelint-selector-bem-pattern"),
+    require.resolve("stylelint-plugin-ecss"),
+  ],
   rules: {
     "plugin/selector-bem-pattern": {
       preset: "suit",
@@ -13,5 +16,6 @@ module.exports = {
     },
     "rule-empty-line-before": ["always", { except: ["first-nested"] }],
     "suitcss/custom-property-no-outside-root": null,
+    "ecss/declaration-comment-magic-numbers-before": true,
   },
 };

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -18,6 +18,7 @@ It adds
   - [stylelint-config-prettier](https://www.npmjs.com/package/stylelint-config-prettier)
   - [stylelint-config-suitcss](https://www.npmjs.com/package/stylelint-config-suitcss)
   - [stylelint-selector-bem-pattern](https://www.npmjs.com/package/stylelint-selector-bem-pattern)
+  - [stylelint-plugin-ecss](https://www.npmjs.com/package/stylelint-plugin-ecss)
 
 ## Installation
 

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -29,6 +29,7 @@
     "stylelint": "^13.6.1",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-suitcss": "^15.0.0",
+    "stylelint-plugin-ecss": "^1.0.1",
     "stylelint-selector-bem-pattern": "^2.1.0"
   }
 }

--- a/packages/css/yarn.lock
+++ b/packages/css/yarn.lock
@@ -3617,6 +3617,13 @@ stylelint-order@^4.1.0:
     postcss "^7.0.31"
     postcss-sorting "^5.0.1"
 
+stylelint-plugin-ecss@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stylelint-plugin-ecss/-/stylelint-plugin-ecss-1.0.1.tgz#b9149b838bed428706aff5eb3ec74bb86823652e"
+  integrity sha512-dLnkdzgescOmqe5FcD5u5t2ULDE01laYwq8WLYfTE5M7ymB/WOK/ZgL37KeyuLlWxMVTInHPqQq4B5HiXBXNzA==
+  dependencies:
+    lodash "^4.17.15"
+
 stylelint-selector-bem-pattern@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/stylelint-selector-bem-pattern/-/stylelint-selector-bem-pattern-2.1.0.tgz#3a78370ab67b777e571ef0fa2059428816f2d5e3"


### PR DESCRIPTION
Magic numbers need to have a comment before the declaration to explain why they are necessary.
The purpose is to enforce using custom properties.

**EDIT:**
There are two points to discuss though:
1. This rule also complains about e.g. `width: 100%`. To me that is not really a magic number.
2. This rule also complains about declarations in `:root` like `--spacing-12: 1.2rem`;

Any ideas? Or would that be a deal breaker for this plugin?