### PR TITLE
feat(css): Adds a task which creates a CSS file with custom properties after import via Figma API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ _Asset folders for fonts, icons, etc., relative from `rootFolder`. These files w
 **`cssFiles`**, default: `[]`<br>
 _The CSS entry files, relative from `rootFolder`. These files will be used to create a build._
 
+**`cssTokens`**<br>
+_Please refer to [packages/css/README.md](packages/css/README.md) for more information._
+
 **`distFolder`**, default: `"dist"`<br>
 _The folder where the build files will be put_
 

--- a/packages/css/README.md
+++ b/packages/css/README.md
@@ -18,6 +18,13 @@ It adds
   - [stylelint-config-prettier](https://www.npmjs.com/package/stylelint-config-prettier)
   - [stylelint-config-suitcss](https://www.npmjs.com/package/stylelint-config-suitcss)
   - [stylelint-selector-bem-pattern](https://www.npmjs.com/package/stylelint-selector-bem-pattern)
+- a token import task
+
+## Content
+
+- [Installation](#installation)
+- [Exclude files from linting](#exclude-files-from-linting)
+- [Design token import](#design-token-import)
 
 ## Installation
 
@@ -71,3 +78,46 @@ module.exports = deepMerge(stylelintConfig, {
 ## Exclude files from linting
 
 If you want to exclude files from linting, you can do it by adding a `.stylelintignore` file to your root where you reference all files that should be ignored.
+
+## Design token import
+
+If you want to use the design token import from Figma, add the following options to your `.factorialrc.js`:
+
+```js
+cssTokens: {
+  figma: {
+    token: "<YOUR_FIGMA_TOKEN>",
+    id: "<THE_FIGMA_FILE_ID>",
+  }
+}
+```
+
+If you do not want to add the Figma token to the repository (as the code might be publicly available), you can set the token as a node environment variable (`FIGMA_TOKEN`) when running the task via CLI.
+
+There are more options available, whose default values can be overwritten like this:
+
+```js
+cssTokens: {
+  file: "css/tokens.css", // the CSS file that will be created – relative to your rootFolder
+  page: "Design tokens", // the name of the page in the Figma file
+  layers: {
+    // the name of the layers in the Figma File
+    typography: "typography",
+    spacings: "spacings",
+    colors: "colors",
+  },
+}
+```
+
+The values used here are the default values.
+
+### Figma setup
+
+As the Figma API does not return the values of styles, you need to create a dedicated page. This page will then be parsed by this package. For this to work, you need to do the following:
+
+1. Create a page called "Design tokens" (or your value of `cssTokens.figma.page`)
+2. On that page, create a dedicated layer for typography, colors and spacings.
+3. Name these layers based on `cssTokens.figma.layers`.
+4. For typography, add text nodes and apply the correct styles. If a style should only be used for e.g. headlines or copy, prefix its name with "headline-", "copy-" etc.
+5. For colors, create rectangles for decoration colors and text nodes for typography colors. Use filling for the rectangles and text color for the text nodes to apply the correct colors. Prefix the names of decoration nodes with "decoration-" and the name of text nodes with "typo-".
+6. For spacings, create rectangles with the size of the spacing.

--- a/packages/css/__tests__/index.spec.js
+++ b/packages/css/__tests__/index.spec.js
@@ -9,6 +9,7 @@ describe("css/index", () => {
     const css = require("..");
     const build = require("../lib/build");
     const lint = require("../lib/lint");
+    const tokenImport = require("../lib/token-import");
 
     expect(css).toEqual({
       stylelint: "stylelint",
@@ -17,6 +18,7 @@ describe("css/index", () => {
       tasks: {
         build,
         lint,
+        "token-import": tokenImport,
       },
     });
   });

--- a/packages/css/__tests__/lib/token-import/index.spec.js
+++ b/packages/css/__tests__/lib/token-import/index.spec.js
@@ -1,0 +1,314 @@
+const chalk = require("chalk");
+
+const rootFolder = "rootFolder";
+const id = "id";
+const token = "token";
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest.resetModules();
+
+  console.log = jest.fn();
+  jest.mock("fs");
+});
+
+describe("tokens/lib/token-import", () => {
+  describe("without config.figma.token", () => {
+    test("returns a rejected Promise and renders an error messages", async () => {
+      const tokenImport = require("../../../lib/token-import");
+      const spy = jest.spyOn(console, "error").mockImplementation();
+
+      const response = tokenImport({ rootFolder });
+
+      expect(spy).toHaveBeenCalledWith(
+        `\n${chalk.red.bold(
+          "Error:"
+        )} cssTokens.figma.token is missing in the configuration file.`
+      );
+      await expect(response).rejects.toEqual(undefined);
+    });
+  });
+
+  describe("without config.figma.id", () => {
+    test("returns a rejected Promise and renders an error messages", async () => {
+      const tokenImport = require("../../../lib/token-import");
+      const spy = jest.spyOn(console, "error").mockImplementation();
+
+      const response = tokenImport({ rootFolder });
+
+      expect(spy).toHaveBeenCalledWith(
+        `\n${chalk.red.bold(
+          "Error:"
+        )} cssTokens.figma.id is missing in the configuration file.`
+      );
+      await expect(response).rejects.toEqual(undefined);
+    });
+  });
+
+  describe("with config.figma.token and config.figma.id", () => {
+    test("fetches data from the Figma API", async () => {
+      mockFetch();
+      jest.mock("../../../lib/token-import/styles/colors");
+      jest.mock("../../../lib/token-import/write-file", () => {
+        return () => Promise.resolve();
+      });
+
+      const tokenImport = require("../../../lib/token-import");
+      const fetch = require("node-fetch");
+
+      await tokenImport({
+        rootFolder,
+        cssTokens: {
+          figma: {
+            id,
+            token,
+          },
+        },
+      });
+
+      expect(fetch).toHaveBeenCalledWith(
+        `https://api.figma.com/v1/files/${id}`,
+        {
+          headers: {
+            "X-Figma-Token": token,
+          },
+        }
+      );
+    });
+
+    describe("failing fetch", () => {
+      describe("due to invalid config.figma.token", () => {
+        test("returns a rejected Promise and renders an error messages", async () => {
+          jest.mock("node-fetch", () => {
+            return jest.fn(() =>
+              Promise.resolve({
+                json: () =>
+                  Promise.resolve({
+                    status: 403,
+                  }),
+              })
+            );
+          });
+
+          const tokenImport = require("../../../lib/token-import");
+          const spy = jest.spyOn(console, "error").mockImplementation();
+
+          await tokenImport({
+            rootFolder,
+            cssTokens: {
+              figma: {
+                id,
+                token,
+              },
+            },
+          }).catch((e) => expect(e).toEqual(undefined));
+
+          expect(spy).toHaveBeenCalledWith(
+            `\n${chalk.red.bold("Error:")} Authentication failed.`
+          );
+        });
+      });
+
+      describe("due to invalid config.figma.id", () => {
+        test("returns a rejected Promise and renders an error messages", async () => {
+          jest.mock("node-fetch", () => {
+            return jest.fn(() =>
+              Promise.resolve({
+                json: () =>
+                  Promise.resolve({
+                    status: 404,
+                  }),
+              })
+            );
+          });
+
+          const tokenImport = require("../../../lib/token-import");
+          const spy = jest.spyOn(console, "error").mockImplementation();
+
+          await tokenImport({
+            rootFolder,
+            cssTokens: {
+              figma: {
+                id,
+                token,
+              },
+            },
+          }).catch((e) => expect(e).toEqual(undefined));
+
+          expect(spy).toHaveBeenCalledWith(
+            `\n${chalk.red.bold("Error:")} Couldn't find Figma file "${id}".`
+          );
+        });
+      });
+    });
+
+    describe("successful fetch", () => {
+      describe("with invalid page name", () => {
+        test("returns a rejected Promise and renders an error messages", async () => {
+          mockFetch();
+
+          const tokenImport = require("../../../lib/token-import");
+          const spy = jest.spyOn(console, "error").mockImplementation();
+          const page = "invalid page name";
+
+          await tokenImport({
+            rootFolder,
+            cssTokens: {
+              page,
+              figma: {
+                id,
+                token,
+              },
+            },
+          }).catch((e) => expect(e).toEqual(undefined));
+
+          expect(spy).toHaveBeenCalledWith(
+            `\n${chalk.red.bold(
+              "Error:"
+            )} Couldn't find page "${page}" in your Figma file.`
+          );
+        });
+      });
+
+      describe("with valid page name", () => {
+        test("calls the correct module for each layer", async () => {
+          mockFetch();
+          jest.mock("../../../lib/token-import/styles/colors");
+          jest.mock("../../../lib/token-import/write-file", () => {
+            return () => Promise.resolve();
+          });
+
+          const tokenImport = require("../../../lib/token-import");
+          const getColors = require("../../../lib/token-import/styles/colors");
+
+          await tokenImport({
+            rootFolder,
+            cssTokens: {
+              figma: {
+                id,
+                token,
+              },
+            },
+          });
+
+          expect(getColors).toHaveBeenCalledWith({
+            name: "colors",
+            colors: [],
+          });
+        });
+
+        test("calls token-import/write-file", async () => {
+          mockFetch();
+          jest.mock("../../../lib/token-import/styles/colors", () => {
+            return () => ["colors"];
+          });
+          jest.mock("../../../lib/token-import/write-file", () => {
+            return jest.fn(() => Promise.resolve());
+          });
+
+          const tokenImport = require("../../../lib/token-import");
+          const writeFile = require("../../../lib/token-import/write-file");
+
+          await tokenImport({
+            rootFolder,
+            cssTokens: {
+              figma: {
+                id,
+                token,
+              },
+            },
+          });
+
+          expect(writeFile).toHaveBeenCalledWith(rootFolder, "css/tokens.css", {
+            colors: ["colors"],
+            outlines: [],
+            radii: [],
+            shadows: [],
+            spacings: [],
+            typography: [],
+          });
+        });
+
+        describe("when writing the css file fails", () => {
+          test("returns a rejected promise", async () => {
+            mockFetch();
+            jest.mock("../../../lib/token-import/styles/colors", () => {
+              return () => Promise.resolve();
+            });
+            jest.mock("../../../lib/token-import/write-file", () => {
+              return jest.fn(() => Promise.reject());
+            });
+
+            const tokenImport = require("../../../lib/token-import");
+
+            const response = tokenImport({
+              rootFolder,
+              cssTokens: {
+                figma: {
+                  id,
+                  token,
+                },
+              },
+            });
+
+            await expect(response).rejects.toEqual(undefined);
+          });
+        });
+
+        describe("when writing the css file succeeds", () => {
+          test("returns a resolved promise", async () => {
+            mockFetch();
+            jest.mock("../../../lib/token-import/styles/colors", () => {
+              return () => Promise.resolve();
+            });
+            jest.mock("../../../lib/token-import/write-file", () => {
+              return jest.fn(() => Promise.resolve());
+            });
+
+            const tokenImport = require("../../../lib/token-import");
+
+            const response = tokenImport({
+              rootFolder,
+              cssTokens: {
+                figma: {
+                  id,
+                  token,
+                },
+              },
+            });
+
+            await expect(response).resolves.toEqual(undefined);
+          });
+        });
+      });
+    });
+  });
+});
+
+/**
+ * @returns {void}
+ */
+function mockFetch() {
+  jest.mock("node-fetch", () => {
+    return jest.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            document: {
+              children: [
+                {
+                  name: "Design tokens",
+                  children: [
+                    {
+                      name: "colors",
+                      colors: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+      })
+    );
+  });
+}

--- a/packages/css/__tests__/lib/token-import/strings/colors.spec.js
+++ b/packages/css/__tests__/lib/token-import/strings/colors.spec.js
@@ -1,0 +1,23 @@
+describe("css/lib/token-import/strings/colors", () => {
+  test("returns an array with deduplicated colors values", () => {
+    const colors = require("../../../../lib/token-import/strings/colors");
+
+    expect(
+      colors([
+        {
+          name: "Primary",
+          values: {
+            r: 255,
+            g: 0,
+            b: 0,
+            a: 1,
+          },
+        },
+      ])
+    ).toEqual(`  --color-Primary-r: 255;
+  --color-Primary-g: 0;
+  --color-Primary-b: 0;
+  --color-Primary-a: 1;
+  --color-Primary: rgba(var(--color-Primary-r), var(--color-Primary-g), var(--color-Primary-b), var(--color-Primary-a));`);
+  });
+});

--- a/packages/css/__tests__/lib/token-import/strings/outlines.spec.js
+++ b/packages/css/__tests__/lib/token-import/strings/outlines.spec.js
@@ -1,0 +1,21 @@
+describe("css/lib/token-import/strings/outlines", () => {
+  test("returns an array with deduplicated outlines values", () => {
+    const outlines = require("../../../../lib/token-import/strings/outlines");
+
+    expect(
+      outlines([
+        {
+          name: "outline-Primary",
+          values: {
+            width: "0.1rem",
+            style: "solid",
+            color: "rgba(255, 0, 0, 1)",
+          },
+        },
+      ])
+    ).toEqual(`  --outline-Primary-width: 0.1rem;
+  --outline-Primary-style: solid;
+  --outline-Primary-color: rgba(255, 0, 0, 1);
+  --outline-Primary: var(--outline-Primary-width) var(--outline-Primary-style) var(--outline-Primary-color);`);
+  });
+});

--- a/packages/css/__tests__/lib/token-import/strings/radii.spec.js
+++ b/packages/css/__tests__/lib/token-import/strings/radii.spec.js
@@ -1,0 +1,23 @@
+describe("css/lib/token-import/strings/radii", () => {
+  test("returns an array with deduplicated radii values", () => {
+    const radii = require("../../../../lib/token-import/strings/radii");
+
+    expect(
+      radii([
+        {
+          name: "radius-Primary",
+          values: {
+            topLeft: "0.1rem",
+            topRight: "0.2rem",
+            bottomRight: "0.3rem",
+            bottomLeft: "0.4rem",
+          },
+        },
+      ])
+    ).toEqual(`  --radius-Primary-top-left: 0.1rem;
+  --radius-Primary-top-right: 0.2rem;
+  --radius-Primary-bottom-right: 0.3rem;
+  --radius-Primary-bottom-left: 0.4rem;
+  --radius-Primary: var(--radius-Primary-top-left) var(--radius-Primary-top-right) var(--radius-Primary-bottom-right) var(--radius-Primary-bottom-left);`);
+  });
+});

--- a/packages/css/__tests__/lib/token-import/strings/shadows.spec.js
+++ b/packages/css/__tests__/lib/token-import/strings/shadows.spec.js
@@ -1,0 +1,38 @@
+describe("css/lib/token-import/strings/shadows", () => {
+  test("returns an array with deduplicated shadows values", () => {
+    const shadows = require("../../../../lib/token-import/strings/shadows");
+
+    expect(
+      shadows([
+        {
+          name: "outer-shadow-Primary",
+          values: {
+            x: "0.4rem",
+            y: "0.4rem",
+            blur: "4rem",
+            color: "rgba(0, 0, 0, 0.25)",
+          },
+        },
+        {
+          name: "inner-shadow-Primary",
+          values: {
+            x: "0.4rem",
+            y: "0.4rem",
+            blur: "1rem",
+            color: "rgba(0, 0, 0, 0.25)",
+            inset: true,
+          },
+        },
+      ])
+    ).toEqual(`  --outer-shadow-Primary-x: 0.4rem;
+  --outer-shadow-Primary-y: 0.4rem;
+  --outer-shadow-Primary-blur: 4rem;
+  --outer-shadow-Primary-color: rgba(0, 0, 0, 0.25);
+  --outer-shadow-Primary: var(--outer-shadow-Primary-x) var(--outer-shadow-Primary-y) var(--outer-shadow-Primary-blur) var(--outer-shadow-Primary-color);
+  --inner-shadow-Primary-x: 0.4rem;
+  --inner-shadow-Primary-y: 0.4rem;
+  --inner-shadow-Primary-blur: 1rem;
+  --inner-shadow-Primary-color: rgba(0, 0, 0, 0.25);
+  --inner-shadow-Primary: inset var(--inner-shadow-Primary-x) var(--inner-shadow-Primary-y) var(--inner-shadow-Primary-blur) var(--inner-shadow-Primary-color);`);
+  });
+});

--- a/packages/css/__tests__/lib/token-import/strings/spacings.spec.js
+++ b/packages/css/__tests__/lib/token-import/strings/spacings.spec.js
@@ -1,0 +1,19 @@
+describe("css/lib/token-import/strings/spacings", () => {
+  test("returns an array with deduplicated spacings values in rgba", () => {
+    const spacings = require("../../../../lib/token-import/strings/spacings");
+
+    expect(
+      spacings([
+        {
+          name: "1",
+          value: "1rem",
+        },
+        {
+          name: "2",
+          value: "2rem",
+        },
+      ])
+    ).toEqual(`  --spacing-1: 1rem;
+  --spacing-2: 2rem;`);
+  });
+});

--- a/packages/css/__tests__/lib/token-import/strings/typography.spec.js
+++ b/packages/css/__tests__/lib/token-import/strings/typography.spec.js
@@ -1,0 +1,25 @@
+describe("css/lib/token-import/strings/typography", () => {
+  test("returns an array with deduplicated typography values", () => {
+    const typography = require("../../../../lib/token-import/strings/typography");
+
+    expect(
+      typography([
+        {
+          name: "Primary",
+          values: {
+            fontStyle: "font-style-value",
+            fontWeight: "font-weight-value",
+            fontSize: "font-size-value",
+            lineHeight: "line-height-value",
+            fontFamily: "font-family-value",
+          },
+        },
+      ])
+    ).toEqual(`  --typo-Primary-font-style: font-style-value;
+  --typo-Primary-font-weight: font-weight-value;
+  --typo-Primary-font-size: font-size-value;
+  --typo-Primary-line-height: line-height-value;
+  --typo-Primary-font-family: font-family-value;
+  --typo-Primary: var(--typo-Primary-font-style) var(--typo-Primary-font-weight) var(--typo-Primary-font-size)/var(--typo-Primary-line-height) var(--typo-Primary-font-family);`);
+  });
+});

--- a/packages/css/__tests__/lib/token-import/styles/colors.spec.js
+++ b/packages/css/__tests__/lib/token-import/styles/colors.spec.js
@@ -1,0 +1,60 @@
+describe("css/lib/token-import/styles/colors", () => {
+  describe("with styles in the artboard", () => {
+    test("returns an array with deduplicated colors values in rgba", () => {
+      const colors = require("../../../../lib/token-import/styles/colors");
+
+      expect(
+        colors({
+          children: [
+            {
+              name: "Primary",
+              fills: [
+                {
+                  color: {
+                    r: 1,
+                    g: 0,
+                    b: 0,
+                    a: 1,
+                  },
+                },
+              ],
+            },
+            // This is an unlikely use case, but for whatever reason
+            // there might be two nodes with the same name.
+            // If that is the case, the second one should be ignored.
+            {
+              name: "Primary",
+              fills: [
+                {
+                  color: "red",
+                },
+              ],
+            },
+          ],
+        })
+      ).toEqual([
+        {
+          name: "Primary",
+          values: {
+            r: 255,
+            g: 0,
+            b: 0,
+            a: 1,
+          },
+        },
+      ]);
+    });
+  });
+
+  describe("without styles in the artboard", () => {
+    test("returns an empty array", () => {
+      const colors = require("../../../../lib/token-import/styles/colors");
+
+      expect(
+        colors({
+          children: [],
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/css/__tests__/lib/token-import/styles/outlines.spec.js
+++ b/packages/css/__tests__/lib/token-import/styles/outlines.spec.js
@@ -1,0 +1,109 @@
+describe("css/lib/token-import/styles/outlines", () => {
+  describe("with styles in the artboard", () => {
+    test("returns an array with deduplicated outlines values", () => {
+      const outlines = require("../../../../lib/token-import/styles/outlines");
+
+      expect(
+        outlines(
+          {
+            children: [
+              {
+                name: "should-be-ignored",
+                strokeWeight: 5,
+                strokes: [
+                  {
+                    type: "SOLID",
+                  },
+                ],
+                styles: {},
+              },
+              {
+                type: "RECTANGLE",
+                name: "outline-1",
+                strokeWeight: 1,
+                strokes: [
+                  {
+                    type: "SOLID",
+                    color: {
+                      r: 1,
+                      g: 0,
+                      b: 0,
+                      a: 1,
+                    },
+                  },
+                ],
+                styles: {},
+              },
+              {
+                type: "RECTANGLE",
+                name: "outline-3",
+                strokeWeight: 3,
+                strokes: [
+                  {
+                    type: "SOLID",
+                  },
+                ],
+                styles: {
+                  stroke: "ID_3",
+                },
+              },
+              // This is an unlikely use case, but for whatever reason
+              // there might be two nodes with the same name.
+              // If that is the case, the second one should be ignored.
+              {
+                type: "RECTANGLE",
+                name: "outline-3",
+                strokeWeight: 3,
+                strokes: [
+                  {
+                    type: "SOLID",
+                  },
+                ],
+                styles: {
+                  stroke: "ID_4",
+                },
+              },
+            ],
+          },
+          {
+            ID_3: {
+              name: "Stroke3",
+            },
+            ID_4: {
+              name: "Stroke4",
+            },
+          }
+        )
+      ).toEqual([
+        {
+          name: "outline-1",
+          values: {
+            width: "0.1rem",
+            style: "solid",
+            color: "rgba(255, 0, 0, 1)",
+          },
+        },
+        {
+          name: "outline-3",
+          values: {
+            width: "0.3rem",
+            style: "solid",
+            color: "var(--color-decoration-Stroke3)",
+          },
+        },
+      ]);
+    });
+  });
+
+  describe("without styles in the artboard", () => {
+    test("returns an empty array", () => {
+      const outlines = require("../../../../lib/token-import/styles/outlines");
+
+      expect(
+        outlines({
+          children: [],
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/css/__tests__/lib/token-import/styles/radii.spec.js
+++ b/packages/css/__tests__/lib/token-import/styles/radii.spec.js
@@ -1,0 +1,49 @@
+describe("css/lib/token-import/styles/radii", () => {
+  describe("with styles in the artboard", () => {
+    test("returns an array with deduplicated radii values", () => {
+      const radii = require("../../../../lib/token-import/styles/radii");
+
+      expect(
+        radii({
+          children: [
+            {
+              type: "RECTANGLE",
+              name: "radius-3",
+              rectangleCornerRadii: [1, 2, 3, 4],
+            },
+            // This is an unlikely use case, but for whatever reason
+            // there might be two nodes with the same name.
+            // If that is the case, the second one should be ignored.
+            {
+              type: "RECTANGLE",
+              name: "radius-3",
+              rectangleCornerRadii: [1, 2, 3, 4],
+            },
+          ],
+        })
+      ).toEqual([
+        {
+          name: "radius-3",
+          values: {
+            topLeft: "0.1rem",
+            topRight: "0.2rem",
+            bottomRight: "0.3rem",
+            bottomLeft: "0.4rem",
+          },
+        },
+      ]);
+    });
+  });
+
+  describe("without styles in the artboard", () => {
+    test("returns an empty array", () => {
+      const radii = require("../../../../lib/token-import/styles/radii");
+
+      expect(
+        radii({
+          children: [],
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/css/__tests__/lib/token-import/styles/shadows.spec.js
+++ b/packages/css/__tests__/lib/token-import/styles/shadows.spec.js
@@ -1,0 +1,111 @@
+describe("css/lib/token-import/styles/shadows", () => {
+  describe("with styles in the artboard", () => {
+    test("returns an array with deduplicated shadows values", () => {
+      const shadows = require("../../../../lib/token-import/styles/shadows");
+
+      expect(
+        shadows({
+          children: [
+            {
+              type: "RECTANGLE",
+              name: "outer-shadow-Default",
+              effects: [
+                {
+                  offset: {
+                    x: 20,
+                    y: 30,
+                  },
+                  radius: 40,
+                  color: {
+                    r: 1,
+                    g: 0,
+                    b: 0,
+                    a: 1,
+                  },
+                  type: "DROP_SHADOW",
+                },
+              ],
+            },
+            {
+              type: "RECTANGLE",
+              name: "outer-shadow-Active",
+              effects: [
+                {
+                  offset: {
+                    x: 20,
+                    y: 30,
+                  },
+                  radius: 40,
+                  color: {
+                    r: 1,
+                    g: 0,
+                    b: 0,
+                    a: 1,
+                  },
+                  type: "INNER_SHADOW",
+                },
+              ],
+            },
+            // This is an unlikely use case, but for whatever reason
+            // there might be two nodes with the same name.
+            // If that is the case, the second one should be ignored.
+            {
+              type: "RECTANGLE",
+              name: "outer-shadow-Active",
+              effects: [
+                {
+                  offset: {
+                    x: 20,
+                    y: 30,
+                  },
+                  radius: 40,
+                  color: {
+                    r: 1,
+                    g: 0,
+                    b: 0,
+                    a: 1,
+                  },
+                  type: "INNER_SHADOW",
+                },
+              ],
+            },
+            //
+          ],
+        })
+      ).toEqual([
+        {
+          name: "outer-shadow-Default",
+          values: {
+            x: "2rem",
+            y: "3rem",
+            blur: "4rem",
+            color: "rgba(255, 0, 0, 1)",
+            inset: false,
+          },
+        },
+        {
+          name: "outer-shadow-Active",
+          values: {
+            x: "2rem",
+            y: "3rem",
+            blur: "4rem",
+            color: "rgba(255, 0, 0, 1)",
+            inset: true,
+          },
+        },
+      ]);
+    });
+  });
+
+  describe("without styles in the artboard", () => {
+    test("returns an empty array", () => {
+      const shadows = require("../../../../lib/token-import/styles/shadows");
+
+      expect(
+        shadows({
+          children: [],
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/css/__tests__/lib/token-import/styles/spacings.spec.js
+++ b/packages/css/__tests__/lib/token-import/styles/spacings.spec.js
@@ -1,0 +1,48 @@
+describe("css/lib/token-import/styles/spacings", () => {
+  describe("with styles in the artboard", () => {
+    test("returns an array with deduplicated spacings values in rem", () => {
+      const spacings = require("../../../../lib/token-import/styles/spacings");
+
+      expect(
+        spacings({
+          children: [
+            {
+              name: 12,
+              type: "RECTANGLE",
+              absoluteBoundingBox: {
+                width: 12,
+              },
+            },
+            // This is an unlikely use case, but for whatever reason
+            // there might be two nodes with the same name.
+            // If that is the case, the second one should be ignored.
+            {
+              name: 12,
+              type: "RECTANGLE",
+              absoluteBoundingBox: {
+                width: 12,
+              },
+            },
+          ],
+        })
+      ).toEqual([
+        {
+          name: "12",
+          value: "1.2rem",
+        },
+      ]);
+    });
+  });
+
+  describe("without styles in the artboard", () => {
+    test("returns an empty array", () => {
+      const spacings = require("../../../../lib/token-import/styles/spacings");
+
+      expect(
+        spacings({
+          children: [],
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/css/__tests__/lib/token-import/styles/typography.spec.js
+++ b/packages/css/__tests__/lib/token-import/styles/typography.spec.js
@@ -1,0 +1,63 @@
+describe("css/lib/token-import/styles/typography", () => {
+  describe("with styles in the artboard", () => {
+    test("returns an array with deduplicated typography values in rem", () => {
+      const typography = require("../../../../lib/token-import/styles/typography");
+
+      expect(
+        typography({
+          children: [
+            {
+              name: "Primary",
+              style: {
+                fontFamily: "font-family-value",
+                fontWeight: "font-weight-value",
+                fontSize: 24,
+                italic: true,
+                letterSpacing: 0.5252525,
+                lineHeightPercent: 150.12345,
+              },
+            },
+            // This is an unlikely use case, but for whatever reason
+            // there might be two nodes with the same name.
+            // If that is the case, the second one should be ignored.
+            {
+              name: "Primary",
+              style: {
+                fontFamily: "font-family-value",
+                fontWeight: "font-weight-value",
+                fontSize: 24,
+                italic: true,
+                letterSpacing: 0.5252525,
+                lineHeightPercent: 150.12345,
+              },
+            },
+          ],
+        })
+      ).toEqual([
+        {
+          name: "Primary",
+          values: {
+            fontFamily: "font-family-value",
+            fontWeight: "font-weight-value",
+            fontSize: "2.4rem",
+            fontStyle: "italic",
+            letterSpacing: "0.53",
+            lineHeight: "1.50",
+          },
+        },
+      ]);
+    });
+  });
+
+  describe("without styles in the artboard", () => {
+    test("returns an empty array", () => {
+      const typography = require("../../../../lib/token-import/styles/typography");
+
+      expect(
+        typography({
+          children: [],
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/packages/css/__tests__/lib/token-import/write-file.spec.js
+++ b/packages/css/__tests__/lib/token-import/write-file.spec.js
@@ -1,0 +1,229 @@
+const chalk = require("chalk");
+const path = require("path");
+
+const rootFolder = "rootFolder";
+const file = "css/tokens.css";
+const styles = {
+  colors: [
+    {
+      name: "Primary",
+      values: {
+        r: 255,
+        g: 0,
+        b: 0,
+        a: 1,
+      },
+    },
+  ],
+  outlines: [
+    {
+      name: "outline-1",
+      values: {
+        width: ".1rem",
+        style: "solid",
+        color: "var(--color-Primary)",
+      },
+    },
+  ],
+  radii: [
+    {
+      name: "radius-3",
+      values: {
+        topLeft: ".3rem",
+        topRight: ".3rem",
+        bottomRight: ".3rem",
+        bottomLeft: ".3rem",
+      },
+    },
+  ],
+  shadows: [
+    {
+      name: "shadow-Default",
+      values: {
+        x: ".1rem",
+        y: ".1rem",
+        blur: "1rem",
+        color: "rgba(0, 0, 0, 1)",
+      },
+    },
+  ],
+  spacings: [
+    {
+      name: "12",
+      value: "1.2rem",
+    },
+  ],
+  typography: [
+    {
+      name: "Primary",
+      values: {
+        fontStyle: "font-style-value",
+        fontWeight: "font-weight-value",
+        fontSize: "font-size-value",
+        lineHeight: "line-height-value",
+        fontFamily: "font-family-value",
+      },
+    },
+  ],
+};
+
+jest.mock("../../../lib/token-import/strings/colors", () => () => "colors");
+jest.mock("../../../lib/token-import/strings/outlines", () => () => "outlines");
+jest.mock("../../../lib/token-import/strings/radii", () => () => "radii");
+jest.mock("../../../lib/token-import/strings/shadows", () => () => "shadows");
+jest.mock("../../../lib/token-import/strings/spacings", () => () => "spacings");
+jest.mock("../../../lib/token-import/strings/typography", () => () =>
+  "typography"
+);
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest.resetModules();
+
+  console.log = jest.fn();
+});
+
+describe("css/lib/token-import/write-file", () => {
+  describe("successful", () => {
+    test("calls fs.writeFileSync, logs a message and returns a resolved Promise", async () => {
+      jest.mock("fs", () => {
+        return {
+          mkdirSync: jest.fn(),
+          writeFileSync: jest.fn(),
+        };
+      });
+      const fs = require("fs");
+      const spy = jest.spyOn(console, "log");
+      const writeFile = require("../../../lib/token-import/write-file");
+
+      const response = writeFile(rootFolder, file, styles);
+
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      expect(spy).toHaveBeenCalledWith(
+        chalk.green(`\nCreated rootFolder/css/tokens.css!`)
+      );
+      await expect(response).resolves.toEqual(undefined);
+    });
+
+    describe("with properties", () => {
+      test("calls fs.writeFileSync with the correct string", () => {
+        jest.mock("fs", () => {
+          return {
+            mkdirSync: jest.fn(),
+            writeFileSync: jest.fn(),
+          };
+        });
+
+        const fs = require("fs");
+        const spy = jest.spyOn(fs, "writeFileSync");
+
+        const writeFile = require("../../../lib/token-import/write-file");
+
+        writeFile(rootFolder, file, styles);
+
+        expect(spy).toHaveBeenCalledWith(
+          path.join(rootFolder, file),
+          `html {
+colors
+
+outlines
+
+radii
+
+shadows
+
+spacings
+
+typography
+}
+`
+        );
+      });
+    });
+
+    describe("without properties", () => {
+      test("calls fs.writeFileSync with the correct string", () => {
+        jest.mock("fs", () => {
+          return {
+            mkdirSync: jest.fn(),
+            writeFileSync: jest.fn(),
+          };
+        });
+
+        const fs = require("fs");
+        const spy = jest.spyOn(fs, "writeFileSync");
+
+        const writeFile = require("../../../lib/token-import/write-file");
+
+        writeFile(rootFolder, file, {
+          colors: [],
+          outlines: [],
+          radii: [],
+          shadows: [],
+          spacings: [],
+          typography: [],
+        });
+
+        expect(spy).toHaveBeenCalledWith(
+          path.join(rootFolder, file),
+          "html {}\n"
+        );
+      });
+    });
+  });
+
+  describe("not successful", () => {
+    describe("creating folder failed", () => {
+      test("logs an error message and returns a rejected Promise", async () => {
+        jest.mock("fs", () => {
+          return {
+            mkdirSync: () => {
+              throw new Error("error");
+            },
+          };
+        });
+        console.error = jest.fn();
+
+        const spy = jest.spyOn(console, "error");
+        const writeFile = require("../../../lib/token-import/write-file");
+
+        const response = writeFile(rootFolder, file, styles);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenNthCalledWith(
+          1,
+          chalk.red(`\nCreating ${path.join(rootFolder, file)} failed!`)
+        );
+        expect(spy).toHaveBeenNthCalledWith(2, "error");
+        await expect(response).rejects.toEqual(undefined);
+      });
+    });
+
+    describe("creating file failed", () => {
+      test("logs an error message and returns a rejected Promise", async () => {
+        jest.mock("fs", () => {
+          return {
+            mkdirSync: () => {},
+            writeFileSync: () => {
+              throw new Error("error");
+            },
+          };
+        });
+        console.error = jest.fn();
+
+        const spy = jest.spyOn(console, "error");
+        const writeFile = require("../../../lib/token-import/write-file");
+
+        const response = writeFile(rootFolder, file, styles);
+
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenNthCalledWith(
+          1,
+          chalk.red(`\nCreating ${path.join(rootFolder, file)} failed!`)
+        );
+        expect(spy).toHaveBeenNthCalledWith(2, "error");
+        await expect(response).rejects.toEqual(undefined);
+      });
+    });
+  });
+});

--- a/packages/css/index.js
+++ b/packages/css/index.js
@@ -1,6 +1,7 @@
 const path = require("path");
 
 const build = require("./lib/build");
+const tokenImport = require("./lib/token-import");
 const lint = require("./lib/lint");
 
 const stylelintConfig = require(path.join(__dirname, ".stylelintrc")); // eslint-disable-line
@@ -12,5 +13,6 @@ module.exports = {
   tasks: {
     build,
     lint,
+    "token-import": tokenImport,
   },
 };

--- a/packages/css/lib/token-import/converter.js
+++ b/packages/css/lib/token-import/converter.js
@@ -1,0 +1,7 @@
+module.exports = {
+  getColor({ r, g, b, a }) {
+    return `rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(
+      b * 255
+    )}, ${a})`;
+  },
+};

--- a/packages/css/lib/token-import/index.js
+++ b/packages/css/lib/token-import/index.js
@@ -1,0 +1,131 @@
+const chalk = require("chalk");
+const deepMerge = require("deepmerge");
+const fetch = require("node-fetch");
+
+const writeFile = require("./write-file");
+const getColors = require("./styles/colors");
+const getOutlines = require("./styles/outlines");
+const getRadii = require("./styles/radii");
+const getShadows = require("./styles/shadows");
+const getSpacings = require("./styles/spacings");
+const getTypography = require("./styles/typography");
+
+module.exports = async function createTokens({ rootFolder, cssTokens = {} }) {
+  console.log(`\n${chalk.magenta.bold("Importing tokens")}…`);
+
+  const config = deepMerge(
+    {
+      file: "css/tokens.css",
+      figma: {
+        token: null,
+        id: null,
+      },
+      page: "Design tokens",
+      layers: {
+        colors: "colors",
+        other: "other",
+        spacings: "spacings",
+        typography: "typography",
+      },
+    },
+    cssTokens
+  );
+  const styles = {};
+
+  if (process.env.FIGMA_TOKEN) {
+    config.figma.token = process.env.FIGMA_TOKEN;
+  }
+
+  if (!config.figma.token || !config.figma.id) {
+    if (!config.figma.token) {
+      console.error(
+        `\n${chalk.red.bold(
+          "Error:"
+        )} cssTokens.figma.token is missing in the configuration file.`
+      );
+    }
+    if (!config.figma.id) {
+      console.error(
+        `\n${chalk.red.bold(
+          "Error:"
+        )} cssTokens.figma.id is missing in the configuration file.`
+      );
+    }
+    return Promise.reject();
+  }
+
+  // @ts-ignore
+  const result = await fetch(
+    `https://api.figma.com/v1/files/${config.figma.id}`,
+    {
+      headers: {
+        "X-Figma-Token": config.figma.token,
+      },
+    }
+  );
+
+  const structure = await result.json();
+  if (
+    structure.status &&
+    (structure.status === 403 || structure.status === 404)
+  ) {
+    if (structure.status === 403) {
+      console.error(`\n${chalk.red.bold("Error:")} Authentication failed.`);
+    }
+    if (structure.status === 404) {
+      console.error(
+        `\n${chalk.red.bold("Error:")} Couldn't find Figma file "${
+          config.figma.id
+        }".`
+      );
+    }
+    return Promise.reject();
+  }
+
+  if (!structure.document || !structure.document.children) {
+    return Promise.reject();
+  }
+
+  const artboard = structure.document.children.find(
+    ({ name }) => name === config.page
+  );
+  if (!artboard) {
+    console.error(
+      `\n${chalk.red.bold("Error:")} Couldn't find page "${
+        config.page
+      }" in your Figma file.`
+    );
+    return Promise.reject();
+  }
+
+  if (!artboard.children) {
+    return Promise.reject();
+  }
+
+  styles.colors = getColors(
+    artboard.children.find(({ name }) => name === config.layers.colors)
+  );
+  // In the Figma file a color from the "local styles" might be used for outlines.
+  // To reflect that in our outline custom properties, we should use the custom property for the respective color.
+  // To be able to do that, we need to pass the styles here.
+  styles.outlines = getOutlines(
+    artboard.children.find(({ name }) => name === config.layers.other),
+    structure.styles
+  );
+  styles.radii = getRadii(
+    artboard.children.find(({ name }) => name === config.layers.other)
+  );
+  styles.shadows = getShadows(
+    artboard.children.find(({ name }) => name === config.layers.other)
+  );
+  styles.spacings = getSpacings(
+    artboard.children.find(({ name }) => name === config.layers.spacings)
+  );
+  styles.typography = getTypography(
+    artboard.children.find(({ name }) => name === config.layers.typography)
+  );
+
+  return new Promise((resolve, reject) =>
+    writeFile(rootFolder, config.file, styles).then(resolve).catch(reject)
+  );
+};

--- a/packages/css/lib/token-import/strings/colors.js
+++ b/packages/css/lib/token-import/strings/colors.js
@@ -1,0 +1,26 @@
+/**
+ * @param {Array} colors
+ * @returns {string}
+ */
+module.exports = function getColors(colors) {
+  return `${colors
+    .map(({ name = "Default", values }) => getColorsString(name, values))
+    .join("\n")}`;
+};
+
+/**
+ * @param {string} name
+ * @param {object} values
+ * @returns {string}
+ */
+function getColorsString(name, values) {
+  let str = "";
+
+  str += `  --color-${name}-r: ${values.r};\n`;
+  str += `  --color-${name}-g: ${values.g};\n`;
+  str += `  --color-${name}-b: ${values.b};\n`;
+  str += `  --color-${name}-a: ${values.a};\n`;
+  str += `  --color-${name}: rgba(var(--color-${name}-r), var(--color-${name}-g), var(--color-${name}-b), var(--color-${name}-a));`;
+
+  return str;
+}

--- a/packages/css/lib/token-import/strings/outlines.js
+++ b/packages/css/lib/token-import/strings/outlines.js
@@ -1,0 +1,25 @@
+/**
+ * @param {Array} outlines
+ * @returns {string}
+ */
+module.exports = function getOutlines(outlines) {
+  return `${outlines
+    .map(({ name = "Default", values }) => getOutlinesString(name, values))
+    .join("\n")}`;
+};
+
+/**
+ * @param {string} name
+ * @param {object} values
+ * @returns {string}
+ */
+function getOutlinesString(name, values) {
+  let str = "";
+
+  str += `  --${name}-width: ${values.width};\n`;
+  str += `  --${name}-style: ${values.style};\n`;
+  str += `  --${name}-color: ${values.color};\n`;
+  str += `  --${name}: var(--${name}-width) var(--${name}-style) var(--${name}-color);`;
+
+  return str;
+}

--- a/packages/css/lib/token-import/strings/radii.js
+++ b/packages/css/lib/token-import/strings/radii.js
@@ -1,0 +1,26 @@
+/**
+ * @param {Array} radii
+ * @returns {string}
+ */
+module.exports = function getRadii(radii) {
+  return `${radii
+    .map(({ name = "Default", values }) => getRadiiString(name, values))
+    .join("\n")}`;
+};
+
+/**
+ * @param {string} name
+ * @param {object} values
+ * @returns {string}
+ */
+function getRadiiString(name, values) {
+  let str = "";
+
+  str += `  --${name}-top-left: ${values.topLeft};\n`;
+  str += `  --${name}-top-right: ${values.topRight};\n`;
+  str += `  --${name}-bottom-right: ${values.bottomRight};\n`;
+  str += `  --${name}-bottom-left: ${values.bottomLeft};\n`;
+  str += `  --${name}: var(--${name}-top-left) var(--${name}-top-right) var(--${name}-bottom-right) var(--${name}-bottom-left);`;
+
+  return str;
+}

--- a/packages/css/lib/token-import/strings/shadows.js
+++ b/packages/css/lib/token-import/strings/shadows.js
@@ -1,0 +1,32 @@
+/**
+ * @param {Array} shadows
+ * @returns {string}
+ */
+module.exports = function getShadows(shadows) {
+  return `${shadows
+    .map(({ name = "Default", values }) => getShadowsString(name, values))
+    .join("\n")}`;
+};
+
+/**
+ * @param {string} name
+ * @param {object} values
+ * @returns {string}
+ */
+function getShadowsString(name, values) {
+  let str = "";
+
+  str += `  --${name}-x: ${values.x};\n`;
+  str += `  --${name}-y: ${values.y};\n`;
+  str += `  --${name}-blur: ${values.blur};\n`;
+  str += `  --${name}-color: ${values.color};\n`;
+  str += `  --${name}:`;
+
+  if (values.inset) {
+    str += " inset";
+  }
+
+  str += ` var(--${name}-x) var(--${name}-y) var(--${name}-blur) var(--${name}-color);`;
+
+  return str;
+}

--- a/packages/css/lib/token-import/strings/spacings.js
+++ b/packages/css/lib/token-import/strings/spacings.js
@@ -1,0 +1,9 @@
+/**
+ * @param {Array} spacings
+ * @returns {string}
+ */
+module.exports = function getSpacings(spacings) {
+  return `${spacings
+    .map(({ name = "Default", value }) => `  --spacing-${name}: ${value};`)
+    .join("\n")}`;
+};

--- a/packages/css/lib/token-import/strings/typography.js
+++ b/packages/css/lib/token-import/strings/typography.js
@@ -1,0 +1,33 @@
+/**
+ * @param {Array} typography
+ * @returns {string}
+ */
+module.exports = function getTypography(typography) {
+  return `${typography
+    .map(({ name = "Default", values }) => getTypographyString(name, values))
+    .join("\n")}`;
+};
+
+/**
+ * @param {string} name
+ * @param {object} values
+ * @returns {string}
+ */
+function getTypographyString(name, values) {
+  let str = "";
+
+  str += `  --typo-${name}-font-style: ${values.fontStyle};\n`;
+  str += `  --typo-${name}-font-weight: ${values.fontWeight};\n`;
+  str += `  --typo-${name}-font-size: ${values.fontSize};\n`;
+  str += `  --typo-${name}-line-height: ${values.lineHeight};\n`;
+  str += `  --typo-${name}-font-family: ${values.fontFamily};\n`;
+  str += `  --typo-${name}:`;
+
+  if (values.fontStyle !== "none") {
+    str += ` var(--typo-${name}-font-style)`;
+  }
+
+  str += ` var(--typo-${name}-font-weight) var(--typo-${name}-font-size)/var(--typo-${name}-line-height) var(--typo-${name}-font-family);`;
+
+  return str;
+}

--- a/packages/css/lib/token-import/styles/colors.js
+++ b/packages/css/lib/token-import/styles/colors.js
@@ -1,0 +1,29 @@
+module.exports = function getColors(layer) {
+  const styles = [];
+
+  if (layer && layer.children) {
+    layer.children.forEach((child) => {
+      const [fills] = child.fills;
+
+      if (fills) {
+        const { color } = fills;
+        const stringifiedName = child.name.toString();
+
+        if (!styles.find(({ name }) => name === stringifiedName)) {
+          styles.push({
+            name: stringifiedName,
+            id: child.id,
+            values: {
+              r: Math.round(color.r * 255),
+              g: Math.round(color.g * 255),
+              b: Math.round(color.b * 255),
+              a: color.a,
+            },
+          });
+        }
+      }
+    });
+  }
+
+  return styles;
+};

--- a/packages/css/lib/token-import/styles/outlines.js
+++ b/packages/css/lib/token-import/styles/outlines.js
@@ -1,0 +1,39 @@
+const { getColor } = require("../converter");
+
+module.exports = function getOutlines(layer, figmaStyles) {
+  const styles = [];
+
+  if (layer && layer.children) {
+    layer.children.forEach((child) => {
+      if (child.type === "RECTANGLE") {
+        const stringifiedName = child.name.toString();
+
+        if (
+          !styles.find(({ name }) => name === stringifiedName) &&
+          stringifiedName.startsWith("outline-")
+        ) {
+          let color;
+
+          if (child.styles.stroke && figmaStyles[child.styles.stroke]) {
+            color = `var(--color-decoration-${
+              figmaStyles[child.styles.stroke].name
+            })`;
+          } else {
+            color = getColor(child.strokes[0].color);
+          }
+
+          styles.push({
+            name: stringifiedName,
+            values: {
+              width: `${child.strokeWeight / 10}rem`,
+              style: child.strokes[0].type.toLowerCase(),
+              color,
+            },
+          });
+        }
+      }
+    });
+  }
+
+  return styles;
+};

--- a/packages/css/lib/token-import/styles/radii.js
+++ b/packages/css/lib/token-import/styles/radii.js
@@ -1,0 +1,27 @@
+module.exports = function getRadii(layer) {
+  const styles = [];
+
+  if (layer && layer.children) {
+    layer.children.forEach((child) => {
+      if (child.type === "RECTANGLE") {
+        const stringifiedName = child.name.toString();
+        if (
+          !styles.find(({ name }) => name === stringifiedName) &&
+          stringifiedName.startsWith("radius-")
+        ) {
+          styles.push({
+            name: stringifiedName,
+            values: {
+              topLeft: `${child.rectangleCornerRadii[0] / 10}rem`,
+              topRight: `${child.rectangleCornerRadii[1] / 10}rem`,
+              bottomRight: `${child.rectangleCornerRadii[2] / 10}rem`,
+              bottomLeft: `${child.rectangleCornerRadii[3] / 10}rem`,
+            },
+          });
+        }
+      }
+    });
+  }
+
+  return styles;
+};

--- a/packages/css/lib/token-import/styles/shadows.js
+++ b/packages/css/lib/token-import/styles/shadows.js
@@ -1,0 +1,31 @@
+const { getColor } = require("../converter");
+
+module.exports = function getShadows(layer) {
+  const styles = [];
+
+  if (layer && layer.children) {
+    layer.children.forEach((child) => {
+      if (child.type === "RECTANGLE") {
+        const stringifiedName = child.name.toString();
+        if (
+          !styles.find(({ name }) => name === stringifiedName) &&
+          (stringifiedName.startsWith("outer-shadow-") ||
+            stringifiedName.startsWith("inner-shadow-"))
+        ) {
+          styles.push({
+            name: stringifiedName,
+            values: {
+              x: `${child.effects[0].offset.x / 10}rem`,
+              y: `${child.effects[0].offset.y / 10}rem`,
+              blur: `${child.effects[0].radius / 10}rem`,
+              color: getColor(child.effects[0].color),
+              inset: child.effects[0].type === "INNER_SHADOW",
+            },
+          });
+        }
+      }
+    });
+  }
+
+  return styles;
+};

--- a/packages/css/lib/token-import/styles/spacings.js
+++ b/packages/css/lib/token-import/styles/spacings.js
@@ -1,0 +1,20 @@
+module.exports = function getSpacings(layer) {
+  const styles = [];
+
+  if (layer && layer.children) {
+    layer.children.forEach((child) => {
+      if (child.type === "RECTANGLE") {
+        const stringifiedName = child.name.toString();
+
+        if (!styles.find(({ name }) => name === stringifiedName)) {
+          styles.push({
+            name: stringifiedName,
+            value: `${child.absoluteBoundingBox.width / 10}rem`,
+          });
+        }
+      }
+    });
+  }
+
+  return styles;
+};

--- a/packages/css/lib/token-import/styles/typography.js
+++ b/packages/css/lib/token-import/styles/typography.js
@@ -1,0 +1,32 @@
+module.exports = function getTypography(layer) {
+  const styles = [];
+
+  if (layer && layer.children) {
+    layer.children.forEach((child) => {
+      const stringifiedName = child.name.toString();
+
+      if (!styles.find(({ name }) => name.toString() === stringifiedName)) {
+        const { letterSpacing } = child.style;
+        const lineHeight = child.style.lineHeightPercent / 100;
+
+        styles.push({
+          name: stringifiedName,
+          values: {
+            fontFamily: child.style.fontFamily,
+            fontWeight: child.style.fontWeight,
+            fontSize: `${child.style.fontSize / 10}rem`,
+            fontStyle: `${child.style.italic ? "italic" : "none"}`,
+            letterSpacing: Number.isInteger(letterSpacing)
+              ? letterSpacing
+              : letterSpacing.toFixed(2),
+            lineHeight: Number.isInteger(lineHeight)
+              ? lineHeight
+              : lineHeight.toFixed(2),
+          },
+        });
+      }
+    });
+  }
+
+  return styles;
+};

--- a/packages/css/lib/token-import/write-file.js
+++ b/packages/css/lib/token-import/write-file.js
@@ -1,0 +1,66 @@
+const chalk = require("chalk");
+const fs = require("fs");
+const path = require("path");
+
+const getColors = require("./strings/colors");
+const getOutlines = require("./strings/outlines");
+const getRadii = require("./strings/radii");
+const getShadows = require("./strings/shadows");
+const getSpacings = require("./strings/spacings");
+const getTypography = require("./strings/typography");
+
+/**
+ * @param {string} rootFolder
+ * @param {string} file
+ * @param {object} styles
+ * @param {Array} styles.colors
+ * @param {Array} styles.outlines
+ * @param {Array} styles.radii
+ * @param {Array} styles.shadows
+ * @param {Array} styles.spacings
+ * @param {Array} styles.typography
+ * @returns {Promise}
+ */
+module.exports = function writeFile(rootFolder, file, styles) {
+  const folder = `${rootFolder}/${path.dirname(file)}`;
+  const fullPath = `${folder}/${path.basename(file)}`;
+  const shortPath = fullPath.replace(`${process.cwd()}/`, "");
+
+  let string = "html {";
+  if (styles.colors.length > 0) string += `\n${getColors(styles.colors)}\n`;
+  if (styles.outlines.length > 0)
+    string += `\n${getOutlines(styles.outlines)}\n`;
+  if (styles.radii.length > 0) string += `\n${getRadii(styles.radii)}\n`;
+  if (styles.shadows.length > 0) string += `\n${getShadows(styles.shadows)}\n`;
+  if (styles.spacings.length > 0)
+    string += `\n${getSpacings(styles.spacings)}\n`;
+  if (styles.typography.length > 0)
+    string += `\n${getTypography(styles.typography)}\n`;
+  string += "}\n";
+
+  try {
+    fs.mkdirSync(folder, { recursive: true });
+
+    try {
+      fs.writeFileSync(fullPath, string);
+      console.log(chalk.green(`\nCreated ${shortPath}!`));
+
+      return Promise.resolve();
+    } catch (e) {
+      return onError(e.message, shortPath);
+    }
+  } catch (e) {
+    return onError(e.message, shortPath);
+  }
+};
+
+/**
+ * @param {string} error
+ * @param {string} shortPath
+ * @returns {Promise}
+ */
+function onError(error, shortPath) {
+  console.error(chalk.red(`\nCreating ${shortPath} failed!`));
+  console.error(error);
+  return Promise.reject();
+}

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -19,6 +19,8 @@
     "autoprefixer": "^10.0.0",
     "chalk": "^4.1.0",
     "cssnano": "^4.1.10",
+    "deepmerge": "^4.2.2",
+    "node-fetch": "^2.6.1",
     "postcss": "^8.0.8",
     "postcss-color-function": "^4.1.0",
     "postcss-custom-media": "^7.0.8",

--- a/packages/css/yarn.lock
+++ b/packages/css/yarn.lock
@@ -977,6 +977,11 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -2321,6 +2326,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-releases@^1.1.61:
   version "1.1.61"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.61.tgz#707b0fca9ce4e11783612ba4a2fcba09047af16e"
@@ -3032,9 +3042,9 @@ postcss-values-parser@^4.0.0:
     postcss "^7.0.5"
 
 postcss@>=5.0.19, postcss@^8.0.8:
-  version "8.0.8"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.8.tgz#5a80323a5107c0411451d1513f17984cfcfcc830"
-  integrity sha512-SJpf3Yrghve9ygpOcVhloo6e7q/mkp0YU3FLr3grdZpHmSjgwxTYEIrzkz7cFx27IMLFvIfLBnuw+JrHio14WQ==
+  version "8.0.9"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.0.9.tgz#d112fc1e8bbed550657901550fa736ae3dd25ec5"
+  integrity sha512-9Ikq03Hvb/L6dgnOtNOUbcgg9Rsff5uKrI1TyNTQ2ALpa6psZk1Ar3/Hhxv2Q0rECRGDxtcMUTZIQglXozlrDQ==
   dependencies:
     colorette "^1.2.1"
     line-column "^1.0.2"


### PR DESCRIPTION
This PR adds another task to the CSS package. It allows us to import data from a Figma file which gets parsed and based on that then creates a CSS file containing custom properties.

Right now it will create custom properties for
- colors
- outlines
- radii
- shadows
- spacings
- typography