### PR TITLE
Checks for style property before destructuring it

### DIFF
--- a/packages/css/__tests__/lib/token-import/styles/typography.spec.js
+++ b/packages/css/__tests__/lib/token-import/styles/typography.spec.js
@@ -60,4 +60,16 @@ describe("css/lib/token-import/styles/typography", () => {
       ).toEqual([]);
     });
   });
+
+  describe("child with no 'style' property", () => {
+    test("returns an empty array", () => {
+      const typography = require("../../../../lib/token-import/styles/typography");
+
+      expect(
+        typography({
+          children: [{ name: 'BTN' }]
+        })
+      ).toEqual([])
+    })
+  })
 });

--- a/packages/css/lib/token-import/styles/typography.js
+++ b/packages/css/lib/token-import/styles/typography.js
@@ -5,7 +5,7 @@ module.exports = function getTypography(layer) {
     layer.children.forEach((child) => {
       const stringifiedName = child.name.toString();
 
-      if (!styles.find(({ name }) => name.toString() === stringifiedName)) {
+      if (child.style && !styles.find(({ name }) => name.toString() === stringifiedName)) {
         const { letterSpacing } = child.style;
         const lineHeight = child.style.lineHeightPercent / 100;
 


### PR DESCRIPTION
# Bug

When using the typography token importer, if there's is a token which does not have the `child` property, it would break when destructuring it with `const { letterSpacing } = child.style;`

# Changeset 

- Checks for existence of `style` property in token object before destructuring it.
- Adds test coverage for this edge case