### PR TITLE
fix: Use require.resolve for shareable ESLint configs

### DIFF
--- a/packages/stack-javascript/README.md
+++ b/packages/stack-javascript/README.md
@@ -59,7 +59,7 @@ And add a `.eslintrc.js`:
 module.exports = {
   root: true,
   extends: [
-    "@factorial/stack-javascript/eslint",
+    require.resolve("@factorial/stack-javascript/eslint"),
   ],
 };
 ```

--- a/packages/stack-javascript/__tests__/index.spec.js
+++ b/packages/stack-javascript/__tests__/index.spec.js
@@ -30,7 +30,7 @@ describe("javascript/index", () => {
           content: `module.exports = {
   root: true,
   extends: [
-    "@factorial/stack-javascript/eslint",
+    require.resolve("@factorial/stack-javascript/eslint"),
   ],
 };
 `,

--- a/packages/stack-javascript/index.js
+++ b/packages/stack-javascript/index.js
@@ -14,7 +14,7 @@ module.exports = {
       content: `module.exports = {
   root: true,
   extends: [
-    "@factorial/stack-javascript/eslint",
+    require.resolve("@factorial/stack-javascript/eslint"),
   ],
 };
 `,

--- a/packages/stack-vue/README.md
+++ b/packages/stack-vue/README.md
@@ -38,8 +38,8 @@ And add a `.eslintrc.js`:
 module.exports = {
   root: true,
   extends: [
-    "@factorial/stack-javascript/eslint",
-    "@factorial/stack-vue/eslint/v3,
+    require.resolve("@factorial/stack-javascript/eslint"),
+    require.resolve("@factorial/stack-vue/eslint/v3"),
   ],
 };
 ```

--- a/packages/stack-vue/__tests__/index.spec.js
+++ b/packages/stack-vue/__tests__/index.spec.js
@@ -16,8 +16,8 @@ describe("vue/index", () => {
           content: `module.exports = {
   root: true,
   extends: [
-    "@factorial/stack-javascript/eslint",
-    "@factorial/stack-vue/eslint/v3",
+    require.resolve("@factorial/stack-javascript/eslint"),
+    require.resolve("@factorial/stack-vue/eslint/v3"),
   ],
 };
 `,

--- a/packages/stack-vue/index.js
+++ b/packages/stack-vue/index.js
@@ -11,8 +11,8 @@ module.exports = {
       content: `module.exports = {
   root: true,
   extends: [
-    "@factorial/stack-javascript/eslint",
-    "@factorial/stack-vue/eslint/v3",
+    require.resolve("@factorial/stack-javascript/eslint"),
+    require.resolve("@factorial/stack-vue/eslint/v3"),
   ],
 };
 `,


### PR DESCRIPTION
The ESLint config resolver can only automatically resolve configs if they’re called `eslint-config-factorial` or `@factorial/eslint-config`.

Other package names are possible, if the extended config files are referenced with `require.resolve(…)`.